### PR TITLE
fix: Fix  inside urls into configMap appCheckproxy

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -64,11 +64,11 @@ data:
     [
       {
         "pattern": "/c/.*",
-        "baseUrl": "http://data-store.{{ .Values.global.domain }}:8080"
+        "baseUrl": "http://data-store.{{ .Release.Namespace }}:8080"
       },
       {
         "pattern": "/u/.*",
-        "baseUrl": "http://data-store.{{ .Values.global.domain }}:8080"
+        "baseUrl": "http://data-store.{{ .Release.Namespace }}:8080"
       }
     ]
 ---


### PR DESCRIPTION
The configMap need the Kubernetes internal URL to forward traffic to the data-store.

The namespace is dynamically attached to the service being created.